### PR TITLE
build veteran intake modal ui and connect it to for veterans page

### DIFF
--- a/src/components/VeteranIntakeModal.jsx
+++ b/src/components/VeteranIntakeModal.jsx
@@ -1,0 +1,133 @@
+export default function VeteranIntakeModal({ isOpen, onClose }) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#1f1f1f]/45 px-4 py-8">
+      {/* modal shell */}
+      <div className="relative w-full max-w-3xl overflow-hidden rounded-[1.75rem] border border-[#e4d8c4] bg-white shadow-[0_20px_60px_rgba(31,31,31,0.18)]">
+        
+        {/* top accent area */}
+        <div className="border-b border-[#efe5d6] bg-[#f8f3ea] px-6 py-6 md:px-8">
+          {/* close button */}
+          <button
+            onClick={onClose}
+            className="absolute right-5 top-5 text-sm font-medium text-[#6a6a6a] transition hover:text-[#1f1f1f]"
+          >
+            close
+          </button>
+
+          {/* modal intro */}
+          <p className="mb-3 text-[10px] font-semibold uppercase tracking-[0.28em] text-[#9a6b4a]">
+            Veteran Intake
+          </p>
+
+          <h2 className="mb-3 max-w-2xl text-3xl font-bold leading-tight text-[#1f2f6b] md:text-4xl">
+            Tell us a little about yourself
+          </h2>
+
+          <p className="max-w-2xl text-sm leading-7 text-[#5f5f5f] md:text-base">
+            This helps us get a better sense of your background so we can guide you toward the right opportunities.
+          </p>
+        </div>
+
+        {/* modal content */}
+        <div className="px-6 py-6 md:px-8 md:py-8">
+          {/* form section label */}
+          <div className="mb-6">
+            <h3 className="text-lg font-semibold text-[#1f1f1f]">
+              Basic Information
+            </h3>
+            <p className="mt-1 text-sm leading-6 text-[#6a6a6a]">
+              Start with a few simple details so the platform can better understand what support you may need.
+            </p>
+          </div>
+
+          {/* intake form fields */}
+          <div className="grid gap-5 md:grid-cols-2">
+            <div>
+              <label className="mb-2 block text-sm font-medium text-[#1f1f1f]">
+                Full Name
+              </label>
+              <input
+                type="text"
+                placeholder="Enter your full name"
+                className="w-full rounded-2xl border border-[#e4d8c4] bg-[#faf8f3] px-4 py-3 text-sm text-[#1f1f1f] outline-none transition focus:border-[#9b7a46]"
+              />
+            </div>
+
+            <div>
+              <label className="mb-2 block text-sm font-medium text-[#1f1f1f]">
+                Email
+              </label>
+              <input
+                type="email"
+                placeholder="enter your email"
+                className="w-full rounded-2xl border border-[#e4d8c4] bg-[#faf8f3] px-4 py-3 text-sm text-[#1f1f1f] outline-none transition focus:border-[#9b7a46]"
+              />
+            </div>
+
+            <div>
+              <label className="mb-2 block text-sm font-medium text-[#1f1f1f]">
+                Branch of Service
+              </label>
+              <select className="w-full rounded-2xl border border-[#e4d8c4] bg-[#faf8f3] px-4 py-3 text-sm text-[#1f1f1f] outline-none transition focus:border-[#9b7a46]">
+                <option>Select Branch</option>
+                <option>Army</option>
+                <option>Air Force</option>
+                <option>Navy</option>
+                <option>Marines</option>
+                <option>Coast Guard</option>
+                <option>Space Force</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="mb-2 block text-sm font-medium text-[#1f1f1f]">
+                Career Interest
+              </label>
+              <input
+                type="text"
+                placeholder="ex: Logistics, tech, healthcare"
+                className="w-full rounded-2xl border border-[#e4d8c4] bg-[#faf8f3] px-4 py-3 text-sm text-[#1f1f1f] outline-none transition focus:border-[#9b7a46]"
+              />
+            </div>
+
+            <div className="md:col-span-2">
+              <label className="mb-2 block text-sm font-medium text-[#1f1f1f]">
+                What kind of support are you looking for?
+              </label>
+              <textarea
+                rows="4"
+                placeholder="Share anything that would be helpful here..."
+                className="w-full rounded-2xl border border-[#e4d8c4] bg-[#faf8f3] px-4 py-3 text-sm text-[#1f1f1f] outline-none transition focus:border-[#9b7a46]"
+              />
+            </div>
+          </div>
+
+          {/* modal footer */}
+          <div className="mt-8 flex flex-col gap-3 border-t border-[#efe5d6] pt-6 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs leading-5 text-[#7a7a7a]">
+              This is the first step in the intake process.
+            </p>
+
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <button
+                onClick={onClose}
+                className="inline-flex items-center justify-center rounded-full border border-[#d6c6a8] bg-white px-5 py-2.5 text-sm font-medium text-[#5a4a2f] transition hover:bg-[#f4f1eb]"
+              >
+                Cancel
+              </button>
+
+              <button
+                type="button"
+                className="inline-flex items-center justify-center rounded-full bg-[#9b7a46] px-5 py-2.5 text-sm font-medium text-white transition hover:opacity-90"
+              >
+                Continue
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/VeteranIntakeModal.jsx
+++ b/src/components/VeteranIntakeModal.jsx
@@ -61,7 +61,7 @@ export default function VeteranIntakeModal({ isOpen, onClose }) {
               </label>
               <input
                 type="email"
-                placeholder="enter your email"
+                placeholder="Enter your email"
                 className="w-full rounded-2xl border border-[#e4d8c4] bg-[#faf8f3] px-4 py-3 text-sm text-[#1f1f1f] outline-none transition focus:border-[#9b7a46]"
               />
             </div>

--- a/src/components/VeteranIntakeModal.jsx
+++ b/src/components/VeteranIntakeModal.jsx
@@ -107,7 +107,7 @@ export default function VeteranIntakeModal({ isOpen, onClose }) {
           {/* modal footer */}
           <div className="mt-8 flex flex-col gap-3 border-t border-[#efe5d6] pt-6 sm:flex-row sm:items-center sm:justify-between">
             <p className="text-xs leading-5 text-[#7a7a7a]">
-              This is the first step in the intake process.
+              This is the first step in getting you connected to the right opportunities.
             </p>
 
             <div className="flex flex-col gap-3 sm:flex-row">

--- a/src/components/VeteranIntakeModal.jsx
+++ b/src/components/VeteranIntakeModal.jsx
@@ -13,7 +13,7 @@ export default function VeteranIntakeModal({ isOpen, onClose }) {
             onClick={onClose}
             className="absolute right-5 top-5 text-sm font-medium text-[#6a6a6a] transition hover:text-[#1f1f1f]"
           >
-            close
+            Close
           </button>
 
           {/* modal intro */}

--- a/src/pages/ForVeterans.jsx
+++ b/src/pages/ForVeterans.jsx
@@ -18,7 +18,7 @@ export default function ForVeterans() {
           </h1>
 
           <p className="mx-auto mb-8 max-w-2xl text-sm leading-7 text-[#5f5f5f] md:text-base">
-            share a few details to help us understand your goals and what kind of support you need.
+            Share a few details to help us understand your goals and what kind of support you need.
           </p>
 
           {/* open modal button */}

--- a/src/pages/ForVeterans.jsx
+++ b/src/pages/ForVeterans.jsx
@@ -18,8 +18,7 @@ export default function ForVeterans() {
           </h1>
 
           <p className="mx-auto mb-8 max-w-2xl text-sm leading-7 text-[#5f5f5f] md:text-base">
-            This is the beginning of the intake process and gives veterans a
-            simple way to share what they’re looking for.
+            share a few details to help us understand your goals and what kind of support you need.
           </p>
 
           {/* open modal button */}

--- a/src/pages/ForVeterans.jsx
+++ b/src/pages/ForVeterans.jsx
@@ -1,26 +1,42 @@
-export default function ForVeterans() {
-  return (
-    <div className="mx-auto max-w-[1200px] px-5 py-12 md:py-20 md:px-10">
-      <div className="flex flex-col items-center">
-        <h1 className="font-display text-3xl md:text-5xl font-black text-navy-700 text-center leading-tight">
-          Services for Veterans
-        </h1>
-        
-        <p className="mt-4 text-base md:text-lg text-ink-body text-center max-w-2xl">
-          Comprehensive support designed specifically for veterans and military
-          families transitioning to civilian careers.
-        </p>
+import { useState } from "react";
+import VeteranIntakeModal from "../components/VeteranIntakeModal";
 
-        {/* CTA Button */}
-        <div className="flex justify-center w-full md:w-auto">
-          <a 
-            href="/job-board"
-            className="mt-8 md:mt-10 w-full md:w-auto text-center inline-block rounded-md bg-crimson-700 px-10 py-4 text-sm font-semibold !text-white transition-all hover:bg-crimson-500 active:scale-95 shadow-md"
+export default function ForVeterans() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  return (
+    <section className="bg-[#f7f4ef] px-4 py-16 md:px-8">
+      <div className="mx-auto max-w-6xl">
+        {/* page intro / action trigger */}
+        <div className="text-center">
+          <p className="mb-3 text-[10px] font-semibold uppercase tracking-[0.28em] text-[#9a6b4a]">
+            Veteran Intake
+          </p>
+
+          <h1 className="mb-4 text-4xl font-bold tracking-tight text-[#1f2f6b] md:text-6xl">
+            Start Your Next Step with Vetess
+          </h1>
+
+          <p className="mx-auto mb-8 max-w-2xl text-sm leading-7 text-[#5f5f5f] md:text-base">
+            This is the beginning of the intake process and gives veterans a
+            simple way to share what they’re looking for.
+          </p>
+
+          {/* open modal button */}
+          <button
+            onClick={() => setIsModalOpen(true)}
+            className="inline-flex items-center justify-center rounded-full bg-[#9b7a46] px-6 py-3 text-sm font-medium text-white transition hover:opacity-90"
           >
-            View Job Board
-          </a>
+            Start Intake Form
+          </button>
         </div>
       </div>
-    </div>
+
+      {/* intake modal */}
+      <VeteranIntakeModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+      />
+    </section>
   );
 }


### PR DESCRIPTION
for this task i built a veteran intake modal that opens from the for veterans page. i made it its own component so the main page file didn’t get too messy and so it’s easier to manage instead of having everything in one place.

i used useState in the for veterans page to control when the modal opens and closes. when the user clicks the “start intake form” button, it shows the modal, and when they click close or cancel, it hides it again. i passed that down as props so the modal itself just focuses on the ui.

inside the modal, i structured it to feel like the start of a real intake process. i added a header with a label, title, and short description so the user knows what they’re doing, then built out the form fields like name, email, branch of service, and career interest. i also added a textarea so they can give a little more detail if they want.

for layout, i used a grid so the inputs sit side by side on bigger screens and stack on smaller ones. that way it stays clean and easy to read no matter the screen size.

i also added a background overlay so the modal stands out from the rest of the page and keeps the focus on the form. i styled everything to match the figma, using the same colors, spacing, and typography so it doesn’t feel like a random popup.

the form is frontend only for now, so there’s no backend or submission logic yet. the main focus was just getting the structure, layout, and overall feel of the intake flow right.


<img width="930" height="844" alt="intake ui for ForVeterans pt 2" src="https://github.com/user-attachments/assets/87c18de4-e925-4a12-ac0c-5371c1976815" />
<img width="1135" height="498" alt="intake ui for ForVeterans pt1 " src="https://github.com/user-attachments/assets/e3ee905e-4df3-42c0-8bf4-3909318afb24" />
