### PR TITLE
Build Job Board page layout with fake data and JobCard component

### DIFF
--- a/src/components/JobCard.jsx
+++ b/src/components/JobCard.jsx
@@ -1,0 +1,35 @@
+export default function JobCard({ job }) {
+  return (
+    <div className="bg-white border rounded-2xl p-5 shadow-sm">
+
+      <p className="text-sm text-gray-500">{job.company}</p>
+
+      <h2 className="text-lg font-semibold mt-1">
+        {job.title}
+      </h2>
+
+      <p className="text-sm text-gray-500 mt-1">
+        {job.location} · Full-time
+      </p>
+
+      <p className="text-sm mt-1">{job.salary}</p>
+
+      {/* the tags */}
+      <div className="flex flex-wrap gap-2 mt-3">
+        {job.tags.map((tag, index) => (
+          <span
+            key={index}
+            className="text-xs px-2 py-1 bg-gray-100 rounded"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+
+      {/* apply button */}
+      <button className="mt-4 text-red-700 font-medium">
+        Apply →
+      </button>
+    </div>
+  );
+}

--- a/src/pages/JobBoard.jsx
+++ b/src/pages/JobBoard.jsx
@@ -1,8 +1,91 @@
+import JobCard from "../components/JobCard";
+
+const fakeJobs = [
+  {
+    id: 1,
+    title: "Cybersecurity Analyst",
+    company: "ERA Solutions",
+    location: "Washington, DC",
+    salary: "$85k – $120k",
+    tags: ["Veteran Preferred", "Security Clearance", "Remote OK"],
+  },
+  {
+    id: 2,
+    title: "Operations Manager",
+    company: "ERA Solutions",
+    location: "Seattle, WA",
+    salary: "$95k – $135k",
+    tags: ["Veteran Preferred", "Leadership"],
+  },
+  {
+    id: 3,
+    title: "Project Manager",
+    company: "ERA Solutions",
+    location: "Austin, TX",
+    salary: "$80k – $110k",
+    tags: ["Remote", "Military Spouse OK"],
+  },
+];
+
 export default function JobBoard() {
   return (
-    <div className="mx-auto max-w-[1200px] px-5 py-20 md:px-10">
-      <h1 className="font-display text-5xl font-black text-navy-700">Job Board</h1>
-      <p className="mt-4 text-lg text-ink-body">Student page coming next.</p>
-    </div>
-  )
+    <section className="bg-[#f8f6f2] min-h-screen px-6 py-12">
+      <div className="max-w-6xl mx-auto">
+
+        {/* header */}
+        <div className="mb-8">
+          <p className="text-sm uppercase tracking-wide text-gray-500">
+            Veteran Job Board
+          </p>
+
+          <h1 className="text-4xl font-bold mt-2 mb-2">
+            Find Jobs That Value Your Service
+          </h1>
+
+          <p className="text-gray-600">
+            2,447 openings from employers committed to hiring veterans · Updated daily
+          </p>
+        </div>
+
+        {/* search bar here */}
+        <div className="bg-white rounded-xl shadow p-3 flex flex-col md:flex-row gap-3 mb-8">
+          <input
+            type="text"
+            placeholder="Job title, MOS code, or skill..."
+            className="flex-1 px-4 py-3 rounded-lg border outline-none"
+          />
+
+          <input
+            type="text"
+            placeholder="City, State, or ZIP"
+            className="flex-1 px-4 py-3 rounded-lg border outline-none"
+          />
+
+          <button className="bg-red-700 text-white px-6 py-3 rounded-lg font-semibold">
+            Find Jobs
+          </button>
+        </div>
+
+        {/* tabs here */}
+        <div className="flex gap-6 border-b pb-3 mb-6 text-sm">
+          <button className="font-semibold">List View</button>
+          <button className="text-gray-500">Map View</button>
+          <button className="text-gray-500">Saved Jobs (0)</button>
+        </div>
+
+        {/* results count */}
+        <p className="text-sm text-gray-600 mb-6">
+          Showing 2,447 jobs
+        </p>
+
+        {/* job grid here */}
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {fakeJobs.map((job) => (
+            <JobCard key={job.id} job={job} />
+          ))}
+        </div>
+
+      </div>
+    </section>
+  );
 }


### PR DESCRIPTION
i built out the Job Board page using fake data to get the structure in place.

the i added the /job-board route and set up the page with a header, intro text, and a job listings section so it actually feels like a real job board. created a fakeJobs array and mapped everything into a reusable JobCard component to keep it clean and easy to scale later.

basically each card shows the main info like title, company, location, salary, and tags so it’s not just placeholders, it actually looks usable.

the i went with a grid layout so multiple jobs display nicely and spacing stays consistent across the page. i kept everything static like the ticket said, no real data or functionality yet.

this is the first pass to get the structure solid

i tried to keep the text as close as possible to the Figma so the page already feels aligned and realistic even with placeholder data.

<img width="1367" height="681" alt="JobBoard Layout static " src="https://github.com/user-attachments/assets/7d9916fe-dfd9-4250-b5a8-3208190aa899" />
