### PR TITLE
align about page with figma (fonts, colors, stats layout)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,19 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
+    <!-- Google Fonts (Figma fonts) -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=DM+Sans:wght@400;500;700&family=Playfair+Display:wght@600;700;800;900&display=swap"
+      rel="stylesheet"
+    />
+
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>vetess</title>
   </head>
+
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,40 +1,230 @@
-import { Link } from "react-router-dom";
+import { useEffect, useState } from "react";
+
+function AnimatedNumber({ end, suffix = "", prefix = "", duration = 1600 }) {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let start = 0;
+    const increment = end / (duration / 16);
+
+    const counter = setInterval(() => {
+      start += increment;
+
+      if (start >= end) {
+        setCount(end);
+        clearInterval(counter);
+      } else {
+        setCount(Math.floor(start));
+      }
+    }, 16);
+
+    return () => clearInterval(counter);
+  }, [end, duration]);
+
+  return (
+    <>
+      {prefix}
+      {count.toLocaleString()}
+      {suffix}
+    </>
+  );
+}
 
 export default function About() {
   return (
-    <main className="px-6 py-16 sm:px-8 lg:px-12">
-      {/* about hero section */}
-      <section className="mx-auto max-w-5xl text-center">
-        <p className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-[#8d2227]">
-          About Vetess
-        </p>
-
-        <h1 className="text-4xl font-bold leading-tight text-[#1f2f63] sm:text-5xl">
-          Empowering Veterans Through Opportunity, Support, and Community
+    <main
+      style={{
+        backgroundColor: "#FEFCF8",
+        fontFamily: "'DM Sans', sans-serif",
+        padding: "96px 24px",
+      }}
+    >
+      <section style={{ maxWidth: "900px", margin: "0 auto", textAlign: "center" }}>
+        
+        {/* HERO */}
+        <h1
+          style={{
+            fontFamily: "'Playfair Display', serif",
+            fontWeight: 900,
+            fontSize: "52px",
+            lineHeight: "78px",
+            color: "#1E3060",
+          }}
+        >
+          About VetBridge
         </h1>
 
-        <p className="mx-auto mt-5 max-w-3xl text-base leading-7 text-[#6f6a63] sm:text-lg">
-          Vetess exists to support veterans by connecting them with meaningful
-          opportunities, practical resources, and a community that understands
-          their journey. Our goal is to help veterans move forward with clarity,
-          confidence, and real support.
+        <p
+          style={{
+            marginTop: "24px",
+            maxWidth: "768px",
+            marginInline: "auto",
+            fontSize: "20px",
+            lineHeight: "32.5px",
+            color: "#3D3529",
+          }}
+        >
+          VetBridge is a nonprofit organization dedicated to helping veterans,
+          active duty service members, and military spouses successfully
+          transition to civilian careers.
         </p>
 
-        <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
-          <Link
-            to="/donate"
-            className="rounded-[12px] bg-[#9f1d20] px-6 py-3 text-sm font-semibold !text-white transition hover:bg-[#8d181b]"
+        {/* CARDS */}
+        <div
+          style={{
+            marginTop: "80px",
+            display: "grid",
+            gap: "32px",
+            gridTemplateColumns: "1fr 1fr",
+            textAlign: "left",
+          }}
+        >
+          {/* Mission */}
+          <div
+            style={{
+              border: "1px solid #E9E9CD",
+              borderRadius: "20px",
+              padding: "32px",
+              backgroundColor: "#FFFFFF",
+            }}
           >
-            Donate Now
-          </Link>
+            <h2
+              style={{
+                fontFamily: "'Playfair Display', serif",
+                fontWeight: 700,
+                fontSize: "30px",
+                lineHeight: "36px",
+                color: "#1E3060",
+              }}
+            >
+              Our Mission
+            </h2>
 
-          <Link
-            to="/for-veterans"
-            className="rounded-[12px] border border-[#d8d1c3] bg-white px-6 py-3 text-sm font-semibold text-[#2a3560] transition hover:bg-[#f7f3ea]"
+            <p
+              style={{
+                marginTop: "16px",
+                fontSize: "16px",
+                lineHeight: "26px",
+                color: "#1B1919",
+              }}
+            >
+              We bridge the gap between military service and civilian employment
+              by providing free career services, job placement assistance, and
+              ongoing support to those who have served our country.
+            </p>
+          </div>
+
+          {/* Impact */}
+          <div
+            style={{
+              border: "1px solid #E9E9CD",
+              borderRadius: "20px",
+              padding: "32px",
+              backgroundColor: "#FFFFFF",
+            }}
           >
-            For Veterans
-          </Link>
+            <h2
+              style={{
+                fontFamily: "'Playfair Display', serif",
+                fontWeight: 700,
+                fontSize: "30px",
+                lineHeight: "36px",
+                color: "#1E3060",
+              }}
+            >
+              Our Impact
+            </h2>
+
+            <p
+              style={{
+                marginTop: "16px",
+                fontSize: "16px",
+                lineHeight: "26px",
+                color: "#1B1919",
+              }}
+            >
+              Since our founding, we have helped over 47,000 veterans find
+              meaningful employment, with 94% securing positions within 90 days
+              of program completion.
+            </p>
+          </div>
         </div>
+
+        {/* STATS */}
+<div
+  style={{
+    marginTop: "80px",
+    width: "949px",
+    height: "179.75px",
+    maxWidth: "100%",
+    backgroundColor: "#FFFFFF",
+    borderBottom: "1px solid #EDE0C8",
+    paddingTop: "44px",
+    paddingBottom: "1px",
+    display: "grid",
+    gridTemplateColumns: "repeat(4, 1fr)",
+    textAlign: "center",
+    marginInline: "auto",
+  }}
+>
+  {[
+    { num: 47, suffix: "k+", top: "Veterans", bottom: "Placed" },
+    { num: 2400, suffix: "+", top: "Employers", bottom: "Hiring Now" },
+    { num: 94, suffix: "%", top: "Hired in", bottom: "90 Days" },
+    { num: 0, prefix: "$", top: "Cost to", bottom: "Veterans" },
+  ].map((item, i) => (
+    <div
+      key={i}
+      style={{
+        borderRight: i !== 3 ? "1px solid #EDE0C8" : "none",
+        padding: "0 24px",
+        height: "86px",
+      }}
+    >
+      <p
+        style={{
+          fontFamily: "'DM Mono', monospace",
+          fontWeight: 500,
+          fontSize: "48px",
+          lineHeight: "48px",
+          color: "#8B1A1F",
+        }}
+      >
+        <AnimatedNumber
+          end={item.num}
+          suffix={item.suffix}
+          prefix={item.prefix}
+        />
+      </p>
+
+      <p
+        style={{
+          marginTop: "8px",
+          fontFamily: "'DM Sans', sans-serif",
+          fontWeight: 600,
+          fontSize: "15px",
+          lineHeight: "18.75px",
+          color: "#0A1226",
+        }}
+      >
+        {item.top}
+      </p>
+
+      <p
+        style={{
+          fontFamily: "'DM Sans', sans-serif",
+          fontWeight: 400,
+          fontSize: "12px",
+          lineHeight: "16px",
+          color: "#6F6969",
+        }}
+      >
+        {item.bottom}
+      </p>
+    </div>
+  ))}
+</div>
+
       </section>
     </main>
   );


### PR DESCRIPTION
i updated the About page to fully match the Figma design

i went through each section and aligned everything to the design specs instead of using default Tailwind styles. this includes fixing typography (Playfair Display for headings, DM Sans for body, DM Mono for stats), applying exact font weights and sizes, and correcting all colors to match the design system

rebuilt the stats section to match layout and spacing exactly, including proper width, padding, divider lines, and updated number styling. Also adjusted the mission/impact cards to match border color, radius, and spacing

cleaned up overall spacing and alignment across the page so everything is consistent and centered like the Figma

<img width="1131" height="843" alt="Official About Figma Updated" src="https://github.com/user-attachments/assets/2e97fa8b-4619-4a7b-9bd9-82d04f49bfdb" />


